### PR TITLE
Improve visibility of dotted-math-field shadow

### DIFF
--- a/App/style.css
+++ b/App/style.css
@@ -537,14 +537,15 @@ input[valid=false] {
 }
 
 #dotted-math-field-static {
-  filter: drop-shadow(1px 1px 1px #000);
-  margin-top: auto; 
-  margin-bottom: auto; 
+  border: 2px solid rgba(255,255,255,0.2);
+  backdrop-filter: blur(9px);
+  text-shadow: 0px 0px 8px rgba(0,0,0,0.75);
+  margin-top: auto;
+  margin-bottom: auto;
   font-weight: bold;
   font-family:monospace;
-  color:rgb(0,255,0); 
+  color:rgb(0,255,0);
 }
-
 
 #dotted-slider {
   writing-mode: bt-lr; /* IE */


### PR DESCRIPTION
**Before**
<img width="343" alt="Screen Shot 2022-07-18 at 18 40 32" src="https://user-images.githubusercontent.com/5891442/179629169-2accbf25-db49-4b49-b49b-0207d6c1f57e.png">


**After**
<img width="250" alt="Screen Shot 2022-07-18 at 18 35 34" src="https://user-images.githubusercontent.com/5891442/179629100-ea3962a8-df9d-4a1a-a051-ab237a025a1c.png">
