### PR TITLE
Fix issue #197 by hiding level info div

### DIFF
--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -73,7 +73,11 @@ function World(spec) {
   let levelBubble
 
   function start() {
-    ui.hideLevelInfoButton.addEventListener('click', hideLevelInfoClicked)
+    // Only show the level info if we're not in debug
+    if (!window.location.hostname.endsWith('sinerider.com')) {
+      ui.levelInfoDiv.setAttribute('hide', false)
+      ui.hideLevelInfoButton.addEventListener('click', hideLevelInfoClicked)
+    }
   }
 
   function tick() {
@@ -177,11 +181,6 @@ function World(spec) {
 
     ui.levelInfoNameStr.innerHTML = levelDatum.name
     ui.levelInfoNickStr.innerHTML = levelDatum.nick
-    // Only show the level info if we're not in debug
-    if (window.location.hostname === 'sinerider.com')
-      ui.levelInfoDiv.setAttribute('hide', true)
-    else
-      ui.levelInfoDiv.setAttribute('hide', false)
 
     setNavigating(false)
   }

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -177,7 +177,11 @@ function World(spec) {
 
     ui.levelInfoNameStr.innerHTML = levelDatum.name
     ui.levelInfoNickStr.innerHTML = levelDatum.nick
-    ui.levelInfoDiv.setAttribute('hide', false)
+    // Only show the level info if we're not in debug
+    if (window.location.hostname === 'sinerider.com')
+      ui.levelInfoDiv.setAttribute('hide', true)
+    else
+      ui.levelInfoDiv.setAttribute('hide', false)
 
     setNavigating(false)
   }

--- a/index.html
+++ b/index.html
@@ -228,16 +228,6 @@
 
     <div class="veil" id="veil" hide="true"></div>
 
-    <div class="loading veil" id="loading-veil" hide="false">
-      <div class="string" id="loading-remarks">
-        <p>
-          To load a level from a previous session click the ⛰️ button and then
-          SHOW ALL.
-        </p>
-      </div>
-      <div class="string" id="loading-string"></div>
-    </div>
-
     <div id="lvl-debug-info" hide="true">
       <div class="grid">
         <div class="string debugtitle">Level name:</div>
@@ -248,6 +238,16 @@
       <div class="button" id="button-hide-level-info" hide="true">
         <div class="string">X</div>
       </div>
+    </div>
+
+    <div class="loading veil" id="loading-veil" hide="false">
+      <div class="string" id="loading-remarks">
+        <p>
+          To load a level from a previous session click the ⛰️ button and then
+          SHOW ALL.
+        </p>
+      </div>
+      <div class="string" id="loading-string"></div>
     </div>
 
     <!-- Load External Libraries -->


### PR DESCRIPTION
I check the hostname to hide the debug-info div. If the hostname is not sinerider.com, the div is hidden. I think this is a good solution, because the debug-info div is only for debugging. If you want to see the debug-info div, you can change the hostname to localhost or whatever hostname you use for debugging.