### PR TITLE
Update map to show only unlocked levels

### DIFF
--- a/Libraries/extensions.js
+++ b/Libraries/extensions.js
@@ -132,8 +132,13 @@ math.modLerp = function (a, b, t, mod = TAU, smooth = false) {
   return c
 }
 
-math.unlerp = function (a, b, c) {
-  return (c - a) / (b - a)
+math.unlerp = function (a, b, t) {
+  return (t - a) / (b - a)
+}
+
+math.remap = function (a, b, c, d, t, clamp = false) {
+  if (clamp) t = math.clamp(a, b, t)
+  return math.lerp(c, d, math.unlerp(a, b, t))
 }
 
 math.truncate = function (number, digits = 1) {

--- a/Types/Entities/LevelBubble.js
+++ b/Types/Entities/LevelBubble.js
@@ -8,7 +8,7 @@ function LevelBubble(spec) {
     getEditing,
     tickDelta,
     getBubbleByNick,
-    showAllUsed,
+    getShowAll,
     quad,
   } = spec
 
@@ -105,7 +105,7 @@ function LevelBubble(spec) {
         truncate: [radius + 0.9, radius + 0.9],
         point0: bubble.transform.position,
         point1: transform.position,
-        drawOrder: LAYERS.arrows,
+        drawOrde: LAYERS.arrows,
         parent: self,
       })
 
@@ -172,12 +172,12 @@ function LevelBubble(spec) {
       playable = true
       hilighted = !completed
     } else {
-      playable = showAllUsed()
+      playable = getShowAll()
       hilighted = false
     }
 
     // visible = playable || _.some(requirements, v => v.playable)
-    visible = playable //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
+    visible = true //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
 
     const opacity = visible ? (playable ? 1 : 0.5) : 0
 

--- a/Types/Entities/LevelBubble.js
+++ b/Types/Entities/LevelBubble.js
@@ -177,17 +177,26 @@ function LevelBubble(spec) {
     }
 
     visible = playable || _.some(requirements, (v) => v.playable)
-    // visible = true //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
+  }
 
-    const opacity = visible ? (playable ? 1 : 0.5) : 0
-
+  function refreshArrows() {
     _.each(arrows, (v) => {
-      v.opacity = opacity
+      v.opacity = visible
+        ? playable
+          ? 1
+          : 0.5
+        : v.fromBubble.visible
+        ? 0.5
+        : 0
       v.dashed = !v.toBubble.unlocked
+      v.fadeIn = visible && !v.fromBubble.visible
+      v.fadeOut = !visible && v.fromBubble.visible
     })
   }
 
   function draw() {
+    if (!visible) return
+
     camera.drawThrough(ctx, drawLocal, transform)
     ctx.globalAlpha = 1
   }
@@ -261,6 +270,7 @@ function LevelBubble(spec) {
     linkRequirements,
 
     refreshPlayable,
+    refreshArrows,
 
     get nick() {
       return nick

--- a/Types/Entities/LevelBubble.js
+++ b/Types/Entities/LevelBubble.js
@@ -176,8 +176,8 @@ function LevelBubble(spec) {
       hilighted = false
     }
 
-    // visible = playable || _.some(requirements, v => v.playable)
-    visible = true //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
+    visible = playable || _.some(requirements, (v) => v.playable)
+    // visible = true //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
 
     const opacity = visible ? (playable ? 1 : 0.5) : 0
 

--- a/Types/Entities/LevelBubble.js
+++ b/Types/Entities/LevelBubble.js
@@ -105,7 +105,7 @@ function LevelBubble(spec) {
         truncate: [radius + 0.9, radius + 0.9],
         point0: bubble.transform.position,
         point1: transform.position,
-        drawOrde: LAYERS.arrows,
+        drawOrder: LAYERS.arrows,
         parent: self,
       })
 

--- a/Types/Entities/LevelBubble.js
+++ b/Types/Entities/LevelBubble.js
@@ -8,7 +8,7 @@ function LevelBubble(spec) {
     getEditing,
     tickDelta,
     getBubbleByNick,
-    getShowAll,
+    showAllUsed,
     quad,
   } = spec
 
@@ -105,7 +105,7 @@ function LevelBubble(spec) {
         truncate: [radius + 0.9, radius + 0.9],
         point0: bubble.transform.position,
         point1: transform.position,
-        drawOrde: LAYERS.arrows,
+        drawOrder: LAYERS.arrows,
         parent: self,
       })
 
@@ -172,12 +172,12 @@ function LevelBubble(spec) {
       playable = true
       hilighted = !completed
     } else {
-      playable = getShowAll()
+      playable = showAllUsed()
       hilighted = false
     }
 
     // visible = playable || _.some(requirements, v => v.playable)
-    visible = true //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
+    visible = playable //TODO: implement gradient fade for invisible unmet requirements. Until then, inaccessible levels will always be shown.
 
     const opacity = visible ? (playable ? 1 : 0.5) : 0
 

--- a/Types/Entities/Navigator.js
+++ b/Types/Entities/Navigator.js
@@ -143,6 +143,7 @@ function Navigator(spec) {
 
   function refreshBubbles() {
     _.invokeEach(bubbles, 'refreshPlayable')
+    _.invokeEach(bubbles, 'refreshArrows')
   }
 
   return self.mix({

--- a/Types/Entities/Navigator.js
+++ b/Types/Entities/Navigator.js
@@ -49,7 +49,7 @@ function Navigator(spec) {
       tickDelta,
       getBubbleByNick,
       parent: self,
-      showAllUsed: () => showAll,
+      getShowAll: () => showAll,
       drawOrder: LAYERS.levelBubbles,
     })
 

--- a/Types/Entities/Navigator.js
+++ b/Types/Entities/Navigator.js
@@ -49,7 +49,7 @@ function Navigator(spec) {
       tickDelta,
       getBubbleByNick,
       parent: self,
-      getShowAll: () => showAll,
+      showAllUsed: () => showAll,
       drawOrder: LAYERS.levelBubbles,
     })
 


### PR DESCRIPTION
Fix #295, update `Navigator.js` and `LevelBubble.js` so the map displays only the unlocked levels