### PR TITLE
Add red border to expression envelope for invalid formulas

### DIFF
--- a/App/style.css
+++ b/App/style.css
@@ -528,6 +528,13 @@ input[valid='false'] {
   border-color: #ffffff;
 }
 
+.invalid-exp {
+  -webkit-box-shadow: #f00 0 0 1px 2px, inset #6ae 0 0 2px 0 !important;
+  -moz-box-shadow: #f00 0 0 1px 2px, inset #6ae 0 0 2px 0 !important;
+  box-shadow: #f00 0 0 1px 3px, inset #ffffff 0 0 3px 0 !important;
+  border-color: #ffffff !important;
+}
+
 .helper-bubble {
   width: 150px;
   text-align: center;

--- a/Types/Entities/Level.js
+++ b/Types/Entities/Level.js
@@ -976,6 +976,12 @@ function Level(spec) {
     graph.expression = text
     ui.expressionEnvelope.setAttribute('valid', graph.valid)
 
+    if (!graph.valid) {
+      ui.expressionEnvelope.classList.add('invalid-exp')
+    } else {
+      ui.expressionEnvelope.classList.remove('invalid-exp')
+    }
+
     _.invokeEach(sledders, 'reset')
     _.invokeEach(goals, 'reset')
   }


### PR DESCRIPTION
This PR just adds a red border to the expression envelope when an invalid formula is entered into it.
![image](https://user-images.githubusercontent.com/79737178/227726055-9e265fee-16dd-4840-9f1d-f2425929be08.png)

Closes #210 