### PR TITLE
Replace editable MathField from MathQuill with MathLive equivalent for mobile friendly virtual keyboard

### DIFF
--- a/App/main.js
+++ b/App/main.js
@@ -268,7 +268,7 @@ ui.mathField.addEventListener('input',(ev) => {
   const text = mathquillToMathJS(latex)
   world.level.sendEvent('setGraphExpression', [text, latex])
 });
-ui.mathField.focused = () => ui._mathField.classList.contains('mq-focused')
+ui.mathField.focused = () => document.activeElement == ui.mathField
 
 ui.dottedMathFieldStatic = MQ.StaticMath(ui.dottedMathFieldStatic)
 

--- a/App/main.js
+++ b/App/main.js
@@ -260,6 +260,7 @@ ui.timeSlider.addEventListener('change', () => {
 // MathLive/MathQuill
 
 mathVirtualKeyboard.container = ui.keyboardBar
+mathVirtualKeyboard.actionKeycap = "Go/Stop" // Replace Enter key sigil
 
 window.mathVirtualKeyboard.addEventListener('geometrychange', (ev) => {
   screen.resize()

--- a/App/main.js
+++ b/App/main.js
@@ -50,6 +50,7 @@ const ui = {
   controlBarGFX: document.getElementById("controls-bar-gfx"),
   expressionText: $('#expression-text'),
   expressionEnvelope: $('#expression-envelope'),
+  keyboardBar: $('#keyboard-bar'),
 
   mathFieldLabel: $('#variable-label > .string'),
   _mathField: $('#math-field'),
@@ -255,7 +256,10 @@ ui.timeSlider.addEventListener('change', () => {
     world.level.sendEvent('tVariableChanged', [newT])
   }
 })
-// MathQuill
+
+// MathLive/MathQuill
+
+mathVirtualKeyboard.container = ui.keyboardBar
 
 ui.mathFieldStatic = MQ.StaticMath(ui.mathFieldStatic)
 

--- a/App/main.js
+++ b/App/main.js
@@ -261,6 +261,10 @@ ui.timeSlider.addEventListener('change', () => {
 
 mathVirtualKeyboard.container = ui.keyboardBar
 
+window.mathVirtualKeyboard.addEventListener('geometrychange', (ev) => {
+  screen.resize()
+});
+
 ui.mathFieldStatic = MQ.StaticMath(ui.mathFieldStatic)
 
 ui.mathField.addEventListener('input',(ev) => {

--- a/App/main.js
+++ b/App/main.js
@@ -259,26 +259,11 @@ ui.timeSlider.addEventListener('change', () => {
 
 ui.mathFieldStatic = MQ.StaticMath(ui.mathFieldStatic)
 
-function createMathField(field, eventNameOnEdit) {
-  field = MQ.MathField(field, {
-    handlers: {
-      edit: function () {
-        const text = field.getPlainExpression()
-        const latex = field.latex()
-        world.level.sendEvent(eventNameOnEdit, [text, latex])
-      },
-    },
-  })
-
-  field.getPlainExpression = function () {
-    var tex = field.latex()
-    return mathquillToMathJS(tex)
-  }
-
-  return field
-}
-
-ui.mathField = createMathField(ui.mathField, 'setGraphExpression')
+ui.mathField.addEventListener('input',(ev) => {
+  const latex = ev.target.getValue('latex');
+  const text = mathquillToMathJS(latex)
+  world.level.sendEvent('setGraphExpression', [text, latex])
+});
 ui.mathField.focused = () => ui._mathField.classList.contains('mq-focused')
 
 ui.dottedMathFieldStatic = MQ.StaticMath(ui.dottedMathFieldStatic)

--- a/App/style.css
+++ b/App/style.css
@@ -364,11 +364,11 @@ input[valid='false'] {
   border: 1px solid red;
 }
 
-@media not (pointer: coarse) {
-  math-field::part(virtual-keyboard-toggle) {
-    display: none;
-  }
+math-field::part(virtual-keyboard-toggle) {
+  display: none;
+}
 
+@media not (pointer: coarse) {
   .ML__keyboard {
     display: none;
   }

--- a/App/style.css
+++ b/App/style.css
@@ -236,13 +236,20 @@ input[valid='false'] {
   border: 1px solid red;
 }
 
-#controls-bar {
+#controls-bar-with-keyboard {
   transition: none;
   transition-delay: 0s;
 
   position: absolute;
+  left: 0px;
+  bottom: 0px;
+  right: 0px;
   align-self: center;
 
+  flex-direction: column;
+}
+
+#controls-bar {
   align-items: flex-end;
   justify-content: flex-start;
 
@@ -251,6 +258,7 @@ input[valid='false'] {
   height: 50px;
   border-radius: 0px 5px 0px 0px;
 }
+
 #controls-bar-gfx{
   display: flex;
   position: relative;
@@ -354,6 +362,17 @@ input[valid='false'] {
 
 #math-field[valid='false'] {
   border: 1px solid red;
+}
+
+@media not (pointer: coarse) {
+  math-field::part(virtual-keyboard-toggle) {
+    display: none;
+  }
+}
+
+.ML__keyboard {
+  min-height: var(--keyboard-height);
+  width: 100vw;
 }
 
 #variable-label{

--- a/App/style.css
+++ b/App/style.css
@@ -368,6 +368,10 @@ input[valid='false'] {
   math-field::part(virtual-keyboard-toggle) {
     display: none;
   }
+
+  .ML__keyboard {
+    display: none;
+  }
 }
 
 .ML__keyboard {

--- a/App/style.css
+++ b/App/style.css
@@ -405,6 +405,8 @@ math-field::part(virtual-keyboard-toggle) {
   padding: 14px 10px 13px 10px;
   z-index: 1;
   margin: 0;
+
+  position: relative;
 }
 
 

--- a/App/style.css
+++ b/App/style.css
@@ -194,7 +194,7 @@ body > .bar {
 
   transition: 0.5s;
   pointer-events: none;
-  z-index: 2;
+  z-index: 500;
 }
 
 .victory .envelope {

--- a/Types/Entities/Goals/PathGoal.js
+++ b/Types/Entities/Goals/PathGoal.js
@@ -160,7 +160,7 @@ function PathGoal(spec) {
 
     ui.mathFieldLabel.innerText = 'P='
 
-    ui.mathField.latex(pathExpression)
+    ui.mathField.setValue(pathExpression)
     ui.mathFieldStatic.latex(pathExpression)
 
     oldExpression = world.level.currentLatex
@@ -173,7 +173,7 @@ function PathGoal(spec) {
 
     ui.mathFieldLabel.innerText = 'Y='
 
-    ui.mathField.latex(oldExpression)
+    ui.mathField.setValue(oldExpression)
     ui.mathFieldStatic.latex(oldExpression)
 
     editor.deselect()

--- a/Types/Entities/Level.js
+++ b/Types/Entities/Level.js
@@ -379,7 +379,7 @@ function Level(spec) {
     if (isConstantLakeAndNotBubble()) {
       ui.mathFieldLabel.innerText = 'V='
 
-      ui.mathField.latex(defaultVectorExpression)
+      ui.mathField.setValue(defaultVectorExpression)
       ui.mathFieldStatic.latex(defaultVectorExpression)
     } else if (!runAsCutscene && !isBubbleLevel) {
       ui.stopButton.style.setProperty('--stopbuttonbg', '#f46')
@@ -388,7 +388,7 @@ function Level(spec) {
       ui.expressionEnvelope.classList.remove('hidden')
       ui.mathFieldLabel.innerText = 'Y='
 
-      ui.mathField.latex(startingExpression)
+      ui.mathField.setValue(startingExpression)
       ui.mathFieldStatic.latex(startingExpression)
     }
     if(runAsCutscene){
@@ -828,7 +828,7 @@ function Level(spec) {
       ? defaultVectorExpression
       : defaultExpression
 
-    ui.mathField.latex(expression)
+    ui.mathField.setValue(expression)
 
     self.sendEvent('setGraphExpression', [
       mathquillToMathJS(expression),

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -244,6 +244,7 @@ function World(spec) {
       mathVirtualKeyboard.hide()
     } else {
       mathVirtualKeyboard.show()
+      ui.mathField.focus()
     }
 
     // ui.topBar.setAttribute('hide', navigating)

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -244,6 +244,16 @@ function World(spec) {
       mathVirtualKeyboard.hide()
     } else {
       mathVirtualKeyboard.show()
+      // very hacky way to attach a listener to the enter key on each layer of the virtual keyboard
+      // Currently, the mathVirtualKeyboard DOM elements get destroyed/recreated every time on hide/show,
+      // so we don't have to worry about cleaning up these listeners
+      document.querySelectorAll(".MLK__plate > div").forEach((keyboardLayer) => {
+        keyboardLayer.querySelector(".MLK__rows").lastChild.lastChild.addEventListener("click", (event) => {
+          if (!world.navigating && !world.level?.isRunningAsCutscene)
+            world.toggleRunning()
+        });
+      })
+
       ui.mathField.focus()
     }
 
@@ -390,7 +400,8 @@ function World(spec) {
 
     //ui.timeSlider.setAttribute('hide', false)
     ui.controlBarGFX.style.background = "white"
-    ui.mathField.blur()
+    ui.mathField.focus()
+
     ui.expressionEnvelope.setAttribute('disabled', false)
     ui.resetButton.disabled = false
     //ui.menuBar.setAttribute('hide', false)

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -240,6 +240,12 @@ function World(spec) {
 
     ui.controlBar.setAttribute('hide', navigating)
     ui.navigatorFloatingBar.setAttribute('hide', !navigating)
+    if (navigating) {
+      mathVirtualKeyboard.hide()
+    } else {
+      mathVirtualKeyboard.show()
+    }
+
     // ui.topBar.setAttribute('hide', navigating)
 
     if (navigating) {

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -248,10 +248,7 @@ function World(spec) {
       // Currently, the mathVirtualKeyboard DOM elements get destroyed/recreated every time on hide/show,
       // so we don't have to worry about cleaning up these listeners
       document.querySelectorAll(".MLK__plate > div").forEach((keyboardLayer) => {
-        keyboardLayer.querySelector(".MLK__rows").lastChild.lastChild.addEventListener("click", (event) => {
-          if (!world.navigating && !world.level?.isRunningAsCutscene)
-            world.toggleRunning()
-        });
+        keyboardLayer.querySelector(".MLK__rows").lastChild.lastChild.addEventListener("click", onClickRunButton)
       })
 
       ui.mathField.focus()

--- a/Types/Screen.js
+++ b/Types/Screen.js
@@ -35,7 +35,7 @@ function Screen(spec = {}) {
   const maxFramePoint = Vector2()
 
   function isMobile() {
-    return window.matchMedia('pointer: coarse').matches
+    return /Mobi/i.test(window.navigator.userAgent)
   }
 
   function resize() {

--- a/Types/Screen.js
+++ b/Types/Screen.js
@@ -34,9 +34,20 @@ function Screen(spec = {}) {
   const minFramePoint = Vector2()
   const maxFramePoint = Vector2()
 
+  function isMobile() {
+    return window.matchMedia('pointer: coarse').matches
+  }
+
   function resize() {
     width = element.innerWidth || element.width
     height = element.innerHeight || element.height
+
+    if (isMobile()) {
+      const keyboardElement = $('.MLK__plate')
+      if (keyboardElement != null) {
+        height -= keyboardElement.offsetHeight
+      }
+    }
 
     canvas.width = width
     canvas.height = height

--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
             <div class="string">Y=</div>
           </div>
 
-          <math-field id="math-field"></math-field>
+          <math-field id="math-field" math-virtual-keyboard-policy="manual"></math-field>
 
           <div id="math-field-static"></div>
         </div>

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
           <div class="string">Y=</div>
         </div>
   
-        <div id="math-field"></div>
+        <math-field id="math-field"></math-field>
   
         <div id="math-field-static"></div>
       </div>
@@ -313,7 +313,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.3.0/math.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.9.1/mathquill.min.js"></script>
+    <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.9.1/mathquill.min.js"></script>-->
+
+    <script src="//unpkg.com/mathlive"></script>
 
     <script src="Libraries/lz-string.min.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -313,7 +313,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.20/lodash.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.3.0/math.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/mathquill/0.9.1/mathquill.min.js"></script>-->
 
     <script src="//unpkg.com/mathlive"></script>
 

--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/7.3.0/math.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
-    <script src="//unpkg.com/mathlive"></script>
+    <script src="https://unpkg.com/mathlive@0.92.1/dist/mathlive.min.js"></script>
 
     <script src="Libraries/lz-string.min.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -160,63 +160,66 @@
       <!--</div>-->
     </div>
     
-    <div class="bar floating controls" id="controls-bar"> 
-      <div class="button reset-button" id="try-again-button" hide="true">
-        <div class="string">Try Again</div>
-      </div>
-      <div class="bar floating controls" id="expression-envelope" disabled="false">
-        <div class="label" id="variable-label">
-          <div class="string">Y=</div>
+    <div class="floating" id="controls-bar-with-keyboard">
+      <div class="bar floating controls" id="controls-bar">
+        <div class="button reset-button" id="try-again-button" hide="true">
+          <div class="string">Try Again</div>
         </div>
-  
-        <math-field id="math-field"></math-field>
-  
-        <div id="math-field-static"></div>
-      </div>
-      <div id="controls-bar-gfx">
-        <div id="junction" class="controls"></div>
-        <div class="cb-button tooltip" id="reset-button" data-tooltip="Reset">
-          <div class="string">↺</div>
-        </div>
-        <div class="cb-button tooltip" id="navigator-button" data-tooltip="Map">
-          <div class="string">🌎</div>
-        </div>
-        <div class="volume-container">
-          <div class="cb-button tooltip" id="sound-button" data-tooltip="Volume">
-            🔊
+        <div class="bar floating controls" id="expression-envelope" disabled="false">
+          <div class="label" id="variable-label">
+            <div class="string">Y=</div>
           </div>
-          <input id="volume-slider" type="range" orient="horizontal" />
+
+          <math-field id="math-field"></math-field>
+
+          <div id="math-field-static"></div>
+        </div>
+        <div id="controls-bar-gfx">
+          <div id="junction" class="controls"></div>
+          <div class="cb-button tooltip" id="reset-button" data-tooltip="Reset">
+            <div class="string">↺</div>
+          </div>
+          <div class="cb-button tooltip" id="navigator-button" data-tooltip="Map">
+            <div class="string">🌎</div>
+          </div>
+          <div class="volume-container">
+            <div class="cb-button tooltip" id="sound-button" data-tooltip="Volume">
+              🔊
+            </div>
+            <input id="volume-slider" type="range" orient="horizontal" />
+          </div>
+        </div>
+
+
+        <input class="text" id="expression-text" type="text" hide="true" />
+
+        <div class="button" id="run-button" hide="false">
+          <div class="string">GO</div>
+        </div>
+
+        <div class="button reset-button bar floating controls" id="stop-button" hide="true">
+          <div class="string">STOP</div>
+        </div>
+
+        <div id="time-slider-container" class="controls">
+          <div id="time-slider-ticks">
+            <div class="slider-tick"><div class="slider-tick-label">0s</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">1</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">2</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">3</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">4</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">5</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">6</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">7</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">8</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">9</div></div>
+            <div class="slider-tick"><div class="slider-tick-label">10s</div></div>
+          </div>
+          <input type="range" id="time-slider" value="0" min="0" max="100" step="1"  orient="horizontal">
+
         </div>
       </div>
-
-
-      <input class="text" id="expression-text" type="text" hide="true" />
-
-      <div class="button" id="run-button" hide="false">
-        <div class="string">GO</div>
-      </div>
-  
-      <div class="button reset-button bar floating controls" id="stop-button" hide="true">
-        <div class="string">STOP</div>
-      </div>
-
-      <div id="time-slider-container" class="controls">
-        <div id="time-slider-ticks">
-          <div class="slider-tick"><div class="slider-tick-label">0s</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">1</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">2</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">3</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">4</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">5</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">6</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">7</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">8</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">9</div></div>
-          <div class="slider-tick"><div class="slider-tick-label">10s</div></div>
-        </div>
-        <input type="range" id="time-slider" value="0" min="0" max="100" step="1"  orient="horizontal">
-
-      </div>
+      <div id="keyboard-bar"></div>
     </div>
     
 


### PR DESCRIPTION
I think this PR is still a proof of concept because I'm not sure where and how the mobile keyboard is displayed makes sense yet.

- Use MathLive from CDN as recommended in https://cortexjs.io/mathlive/guides/getting-started/, although we will
probably eventually want to vendor it into the `Libraries` directory since it looks like they breaking changes every few months https://cortexjs.io/mathlive/changelog/
- Instead of creating a MathField dynamically in JS, use the `<math-field>` component from MathLive. This is just for simplicity but we can choose to create it dynamically if necessary.
- Change listener on editable MathField to match MathLive's API
- replace everytime we call `mathfield.latex` with `mathfield.setValue (which takes LaTeX)
  
  
Attach mathlive's virtual keyboard to the mathfield div so it remains visible while editing

By default the mathlive keyboard attaches to `<body>`, but this doesn't
play nice with the rest of the positioning CSS for sinerider and gets
displayed over all the elements at hte bottom of the screen. I'm not
sure if this is the best way to do this, but attaching it to the
expression envelope at least keeps it visible while you're editing it.

- Only display the virtual keyboard toggle on mobile devices using
  snippet from https://cortexjs.io/mathlive/guides/virtual-keyboards/#controlling-the-virtual-toggle-visibility
- Without setting min-height or width on `.ML__keyboard`, I was unable to get the keyboard to display no matter how much fiddling with `flex-{grow,shrink,basis}` I tried. Someone better at CSS might figure out a better solution, but for now I just used the existing `--keyboard-height` from MathLive's CSS and set width to the entire screen width, which seems natural for virtual keyboards
<img src="https://user-images.githubusercontent.com/217050/228332894-3f7c6b8a-1e61-4fcc-a63d-349d663e7fd0.PNG" width="250px">
<img src="https://user-images.githubusercontent.com/217050/228332906-0289cb10-795f-404b-9e08-0c438ad427d2.PNG" width="250px">

## Open questions, some possibly out of scope of this PR
- [x] Virtual keyboard toggling seems inconsistent on android. Hitting toggle sometimes doesn't show the keyboard until I background the browser and load it again, so I suspect it could be something that's causing the screen not to repaint?
- [x] iOS browsers get stuck in a reload loop unless we decrease the number of levels loaded in https://github.com/hackclub/sinerider/blob/45cc754f0e1e2a6717b32d88b341a450c2a51b02/Types/Entities/Navigator.js#L32 or disable https://github.com/hackclub/sinerider/blob/45cc754f0e1e2a6717b32d88b341a450c2a51b02/Types/Entities/LevelBubble.js#L83 (which then makes all the bubbles show as empty squares on the map)
- [x] Although sometimes I see the game running as it does on my laptop, other times there seem to be a lot of graphical artifacts on mobile. e.g. <img src="https://user-images.githubusercontent.com/217050/228335198-a0c7f983-946a-4b73-a42d-5702b27dedfa.PNG" width="250px">
- [x] Enter on the virtual keyboard does not start the sled (do we want it to?)
- [ ] If we're happy with MathLive, for consistency it's probably worth replacing the rest of the MathQuill components (the static ones) with MathLive