### PR TITLE
Proper victory screen v2

### DIFF
--- a/App/main.js
+++ b/App/main.js
@@ -26,6 +26,8 @@ const ui = {
   victoryBar: $('#victory-bar'),
   victoryLabel: $('#victory-label'),
   victoryLabelString: $('#victory-label > .string'),
+  timeTaken: $('#time-taken'),
+  charCount: $('#character-count'),
   nextButton: $('#next-button'),
 
   messageBar: $('#message-bar'),

--- a/App/style.css
+++ b/App/style.css
@@ -363,6 +363,13 @@ input[valid='false'] {
 
 #victory-label {
   flex-grow: 1;
+  font-size: 14px;
+}
+
+#victory-text {
+  margin: 0;
+  text-align: center;
+  font-size: 21px;
 }
 
 #hovertext {
@@ -387,7 +394,7 @@ input[valid='false'] {
   z-index: 1;
   left: 50%;
   transform: translateX(-55%);
-  top: -200%;
+  bottom: 60px;
 }
 
 #hovertext:hover:before {

--- a/App/style.css
+++ b/App/style.css
@@ -182,11 +182,12 @@ body > .bar {
   background: transparent;
   bottom: 20px;
 
+  transition: 0.5s;
   pointer-events: none;
 }
 
 .victory .envelope {
-  flex-basis: 300px;
+  flex-basis: 400px;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.4);
   background: #eee;
   padding: 5px;
@@ -362,6 +363,36 @@ input[valid='false'] {
 
 #victory-label {
   flex-grow: 1;
+}
+
+#hovertext {
+  position: relative;
+  display: inline-block;
+  border-bottom: 1px dotted black;
+}
+
+#hovertext:before {
+  content: attr(data-hover);
+  visibility: hidden;
+  opacity: 0;
+  width: max-content;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 5px;
+  padding: 5px 5px;
+  transition: opacity 1s ease-in-out;
+
+  position: absolute;
+  z-index: 1;
+  left: 50%;
+  transform: translateX(-55%);
+  top: -200%;
+}
+
+#hovertext:hover:before {
+  opacity: 0.5;
+  visibility: visible;
 }
 
 #variables-bar {

--- a/App/style.css
+++ b/App/style.css
@@ -382,23 +382,24 @@ input[valid='false'] {
   content: attr(data-hover);
   visibility: hidden;
   opacity: 0;
-  width: max-content;
+  width: 400px;
+  font-size: 13px;
   background-color: black;
   color: #fff;
   text-align: center;
   border-radius: 5px;
   padding: 5px 5px;
   transition: opacity 1s ease-in-out;
-
-  position: absolute;
   z-index: 1;
-  left: 50%;
-  transform: translateX(-55%);
-  bottom: 60px;
+  
+  position: absolute;
+  bottom: 300%;
+  left: 20%;
+  margin-left: -205px;
 }
 
 #hovertext:hover:before {
-  opacity: 0.5;
+  opacity: 1;
   visibility: visible;
 }
 

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -227,6 +227,9 @@ function World(spec) {
   function levelCompleted(soft = false) {
     setCompletionTime(runTime)
 
+    ui.timeTaken.innerHTML = (Math.round(runTime * 100) / 100) == 1 ? '1 second' : `${Math.round(runTime * 100) / 100} seconds`
+    ui.charCount.innerHTML = (ui.mathFieldStatic.latex().length) == 1 ? '1 character' : `${ui.mathFieldStatic.latex().length} characters`
+
     if (soft) {
       nextLevel(2.5)
     } else {

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -227,8 +227,8 @@ function World(spec) {
   function levelCompleted(soft = false) {
     setCompletionTime(runTime)
 
-    ui.timeTaken.innerHTML = (Math.round(runTime * 100) / 100) == 1 ? '1 second' : `${Math.round(runTime * 100) / 100} seconds`
-    ui.charCount.innerHTML = (ui.mathFieldStatic.latex().length) == 1 ? '1 character' : `${ui.mathFieldStatic.latex().length} characters`
+    ui.timeTaken.innerHTML = Math.round(runTime * 100) / 100
+    ui.charCount.innerHTML = ui.mathFieldStatic.latex().length
 
     if (soft) {
       nextLevel(2.5)

--- a/index.html
+++ b/index.html
@@ -222,7 +222,7 @@
           <div class="string">
             <!-- critical issue with plurality -->
             <h3 id="victory-text">Victory!</h3>
-            <span id="time-taken"></span> seconds, <div id="hovertext" data-hover="The shorter your expression, the higher you score!"><span
+            <span id="time-taken"></span> seconds, <div id="hovertext" data-hover="The shorter the expression, the higher you score!"><span
               id="character-count"></span> characters</div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -219,9 +219,12 @@
     <div class="bar victory floating" id="victory-bar" hide="true">
       <div class="envelope" id="victory-envelope">
         <div class="label" id="victory-label">
-          <div class="string">Victory!</div>
+          <div class="string">
+            <span id="time-taken"></span>, <span
+              id="character-count"></span>
+          </div>
         </div>
-
+      
         <div class="button" id="next-button">
           <div class="string">NEXT</div>
         </div>

--- a/index.html
+++ b/index.html
@@ -221,6 +221,7 @@
         <div class="label" id="victory-label">
           <div class="string">
             <!-- critical issue with plurality -->
+            <h3 id="victory-text">Victory!</h3>
             <span id="time-taken"></span> seconds, <div id="hovertext" data-hover="The shorter your expression, the higher you score!"><span
               id="character-count"></span> characters</div>
           </div>

--- a/index.html
+++ b/index.html
@@ -220,8 +220,9 @@
       <div class="envelope" id="victory-envelope">
         <div class="label" id="victory-label">
           <div class="string">
-            <span id="time-taken"></span>, <span
-              id="character-count"></span>
+            <!-- critical issue with plurality -->
+            <span id="time-taken"></span> seconds, <div id="hovertext" data-hover="The shorter your expression, the higher you score!"><span
+              id="character-count"></span> characters</div>
           </div>
         </div>
       


### PR DESCRIPTION
After reviewing the suggestions made by @polytroper and @grymmy, I rewrote the UI for the victory screen - it's essentially a rework of the simple "Victory!" text. It adds metrics like character count and time taken to travel the level.

This hopefully closes #64 and aligns with what we are looking for.

On hover:
![Wild New Screenshot 2023-04-04 at 11 07 48 PM](https://user-images.githubusercontent.com/105997270/229836881-b6832dba-1c12-43ae-8d1c-01c5c3a27d18.jpg)
