### PR TITLE
Support puzzle level payloads and social scoring submissions via twitter

### DIFF
--- a/App/main.js
+++ b/App/main.js
@@ -39,6 +39,10 @@ const ui = {
   variablesBar: $('#variables-bar'),
   timeString: $('#time-string'),
   completionTime: $('#completion-time'),
+
+  submitTwitterScoreDiv: $('#submit_twitter_score_div'),
+  submitTwitterScoreLink: $('#submit_twitter_score_link'),
+
   controlBar: $('#controls-bar'),
   expressionText: $('#expression-text'),
   expressionEnvelope: $('#expression-envelope'),

--- a/Types/Entities/Level.js
+++ b/Types/Entities/Level.js
@@ -704,6 +704,9 @@ function Level(spec) {
   //  3. Share custom levels
 
   function serialize() {
+    if (urlData?.isPuzzle) {
+      return serializePuzzle()
+    }
     const json = {
       v: 0.1, // TODO: change version handling to World?
       nick: datum.nick,
@@ -724,6 +727,12 @@ function Level(spec) {
       json.t = globalScope.t
     }
     return json
+  }
+
+    // Puzzles are completely serializable using the url data 
+  function serializePuzzle() {
+    urlData.expressionOverride = currentLatex
+    return urlData
   }
 
   function goalFailed(goal) {

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -166,14 +166,23 @@ function World(spec) {
     if (level) level.destroy()
 
     levelBubble = navigator.getBubbleByNick(nick)
+    isPuzzle = urlData?.isPuzzle ?? false
+    var savedLatex
+    if (isPuzzle) {
+        levelDatum = generatePuzzleLevel(urlData)
+        savedLatex = levelDatum.expressionOverride ? levelDatum.expressionOverride : levelDatum.defaultExpression
+    } else {
+      if (nick == 'RANDOM') {
+        levelDatum = generateRandomLevel()
+      }
+      else { 
+        levelDatum = _.find(levelData, (v) => v.nick == nick)
+      }
+      savedLatex = urlData?.savedLatex ?? storage.getLevel(nick)?.savedLatex
 
-    if (nick == 'RANDOM') levelDatum = generateRandomLevel()
-    else levelDatum = _.find(levelData, (v) => v.nick == nick)
-
-    const savedLatex = urlData?.savedLatex ?? storage.getLevel(nick)?.savedLatex
-
-    if (urlData?.goals && urlData?.goals.length)
-      levelDatum.goals = (levelDatum.goals ?? []).concat(urlData?.goals)
+      if (urlData?.goals && urlData?.goals.length)
+        levelDatum.goals = (levelDatum.goals ?? []).concat(urlData?.goals)    
+    }
 
     level = Level({
       ui,
@@ -234,6 +243,10 @@ function World(spec) {
     }
   }
 
+  function makeTwitterSubmissionUrl() {
+    return "https://twitter.com/intent/tweet?text=" + encodeURIComponent("#sinerider " + levelDatum.nick + " " + level.currentLatex.replace(/\s/g, ''))
+  }
+
   function levelCompleted(soft = false) {
     setCompletionTime(runTime)
 
@@ -253,7 +266,14 @@ function World(spec) {
       ui.showAllButton.setAttribute('hide', true)
     }
 
-    levelBubble.complete()
+    const isPuzzle = true
+    if ("isPuzzle" in levelDatum && levelDatum["isPuzzle"]) {
+      ui.submitTwitterScoreDiv.setAttribute('hide', false)
+      ui.submitTwitterScoreLink.setAttribute('href', makeTwitterSubmissionUrl())
+    } else {
+      ui.submitTwitterScoreDiv.setAttribute('hide', true)
+    }
+    levelBubble?.complete()
   }
 
   function transitionNavigating(_navigating, duration = 1, cb) {
@@ -408,6 +428,26 @@ function World(spec) {
       hint: 'Soft eyes, grasshopper.',
       goals,
       sledders,
+    }
+  }
+
+  function generatePuzzleLevel(urlData) {
+    return {
+      isPuzzle: true,
+      name: urlData.name,
+      nick: urlData.nick,
+      drawOrder: LAYERS.level,
+      slider:urlData.slider,
+      x: urlData.x,
+      y: urlData.y,
+      biome: urlData.biome,
+      colors: urlData.colors,
+      defaultExpression: urlData.defaultExpression,
+      expressionOverride: urlData.expressionOverride,
+      hint: urlData.hint,
+      goals: urlData.goals,
+      sledders: urlData.sledders,
+      sprites: urlData.sprites
     }
   }
 

--- a/index.html
+++ b/index.html
@@ -227,16 +227,21 @@
               id="hovertext"
               data-hover="The number of characters in your solution (lower = better)"
             >
-              <span id="character-count"></span>
+              <span id="character-count"></span>              
             </div>
+            <div id="submit_twitter_score_div" hide="true">
+              <a id="submit_twitter_score_link" href="http://google.com" target="_blank">Submit score via Twitter</a>
+            </div>
+
           </div>
+      
         </div>
 
         <div class="button" id="next-button">
           <div class="string">NEXT</div>
         </div>
-      </div>
-    </div>
+        </div>
+    </div>    
 
     <div class="bar floating navigator" id="navigator-floating-bar" hide="true">
       <div class="button" id="show-all-button" hide="false">


### PR DESCRIPTION
This diff adds support for reading puzzle payloads, sharing of them via URLs, and deep linking to Twitter with prepopulated puzzle submission values.

The goal of this diff is to not have zero side effects to the client for non-puzzle URLs.