### PR TITLE
Short hack to hide share links and only show limited twitter prefill

### DIFF
--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -291,6 +291,11 @@ function World(spec) {
   }
 
   function makeTwitterSubmissionUrl() {
+    const twitterPrefill = `#sinerider My solution for the question of the day took ${timeTaken()}sec in ${charCount()} characters.`
+    return (
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterPrefill)}`
+    )
+    // @msw: While implementing a quick-fix, the following is a noop
     return (
       'https://twitter.com/intent/tweet?text=' +
       encodeURIComponent(
@@ -315,16 +320,21 @@ function World(spec) {
     document.execCommand('copy')
   }
 
+  function charCount() {
+    return ui.mathFieldStatic.latex().length
+  }
+
+  function timeTaken() {
+    return Math.round(runTime * 100) / 100
+  }
+
   function levelCompleted(soft = false) {
     setCompletionTime(runTime)
 
-    const timeTaken = Math.round(runTime * 100) / 100
-    const charCount = ui.mathFieldStatic.latex().length
-
     ui.timeTaken.innerHTML =
-      timeTaken + ' second' + (timeTaken === 1 ? '' : 's')
+      timeTaken() + ' second' + (timeTaken() === 1 ? '' : 's')
     ui.charCount.innerHTML =
-      charCount + ' character' + (charCount === 1 ? '' : 's')
+      charCount() + ' character' + (charCount() === 1 ? '' : 's')
 
     if (soft) {
       nextLevel(2.5)
@@ -349,8 +359,9 @@ function World(spec) {
         makeTwitterSubmissionUrl(),
       )
 
-      console.log($('#submit-reddit-score'))
-      $('#submit-reddit-score').onclick = openRedditModal
+      // Hide reddit for the time being
+      // console.log($('#submit-reddit-score'))
+      // $('#submit-reddit-score').onclick = openRedditModal
 
       ui.redditOpenCloseButton.onclick = () =>
         ui.redditOpenModal.setAttribute('hide', true)

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -291,7 +291,7 @@ function World(spec) {
   }
 
   function makeTwitterSubmissionUrl() {
-    const twitterPrefill = `#sinerider My solution for the question of the day took ${timeTaken()}sec in ${charCount()} characters.`
+    const twitterPrefill = `#sinerider #${levelDatum.nick} My solution for the question of the day took ${timeTaken()}sec in ${charCount()} characters.`
     return (
       `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterPrefill)}`
     )

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -291,7 +291,8 @@ function World(spec) {
   }
 
   function makeTwitterSubmissionUrl() {
-    const twitterPrefill = `#sinerider #${levelDatum.nick} My solution for the question of the day took ${timeTaken()}sec in ${charCount()} characters.`
+    const linkToPuzzle = `https://sinerider.com/puzzle/?nick=${levelDatum.nick}`
+    const twitterPrefill = `#sinerider #${levelDatum.nick} My solution for the question of the day took ${timeTaken()}sec in ${charCount()} characters. Try solving it yourself: ${linkToPuzzle}`
     return (
       `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterPrefill)}`
     )

--- a/index.html
+++ b/index.html
@@ -269,15 +269,15 @@
             <br class="puzzle-msg" hide="true" />
             <br class="puzzle-msg" hide="true" />
             <div class="puzzle-msg" hide="true">
-              To see how you rank on the Leaderboard, summon the SineRider
-              bumblebot on
+              Show off your solution and see how you rank up against other solvers on
               <!-- url for submitting is generated when puzzle is solved -->
               <a href="#" target="_blank" id="twitter-submission-url"
                 >Twitter</a
-              >
-              or
+              >.
+              <!-- Hide the reddit button for the time being -->
+              <!-- or -->
               <!-- should include link to puzzle on Reddit -->
-              <a href="#" id="submit-reddit-score">Reddit</a>.
+              <!-- <a href="#" id="submit-reddit-score">Reddit</a>. -->
             </div>
             <br class="puzzle-msg" hide="true" />
             <br class="puzzle-msg" hide="true" />

--- a/vercel.json
+++ b/vercel.json
@@ -13,14 +13,14 @@
           "key": "Access-Control-Allow-Headers",
           "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
         }
-      ],
-      "redirects": [
-        {
-          "source": "/puzzle/",
-          "destination": "https://sinerider-api.hackclub.com/puzzle/",
-          "permanent": false
-        }
       ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/puzzle/",
+      "destination": "https://sinerider-api.hackclub.com/puzzle/",
+      "permanent": false
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,13 @@
           "key": "Access-Control-Allow-Headers",
           "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
         }
+      ],
+      "redirects": [
+        {
+          "source": "/puzzle/",
+          "destination": "https://sinerider-api.hackclub.com/puzzle/",
+          "permanent": false
+        }
       ]
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -18,8 +18,8 @@
   ],
   "redirects": [
     {
-      "source": "/puzzle/",
-      "destination": "https://sinerider-api.hackclub.com/puzzle/",
+      "source": "/puzzle/:id",
+      "destination": "https://sinerider-api.hackclub.com/puzzle/:id",
       "permanent": false
     }
   ]


### PR DESCRIPTION
This is a quick hack to only show the twitter flow on the share dialogue because at the time of writing the reddit prefill doesn't 100% work and the leaderboard can't be posted to (the twitter bot is undergoing changes)

<img width="419" alt="Screenshot 2023-05-08 at 13 14 04" src="https://user-images.githubusercontent.com/5891442/236887853-107135d9-d932-4512-99b0-4e1f8715ab02.png">

This also updates the twitter message to just show a human message because we don't expect the bot to respond to these.

<img width="609" alt="Screenshot 2023-05-08 at 13 13 26" src="https://user-images.githubusercontent.com/5891442/236888052-6dfeaaf8-a5a4-4fb4-b269-2f82bc095f87.png">
