### PR TITLE
Make Sinerider playable on Firefox

### DIFF
--- a/App/main.js
+++ b/App/main.js
@@ -204,15 +204,13 @@ var numTicks = 0
 function tick() {
   tickInternal()
 
-  // setTimeout imposes a minimum overhead as the delay approaches 0, and thus it becomes very likely
-  // that our timer loop will fall behind our desired tick rate at ticks/sec > 250
+  // setTimeout and rendering impose some minimum overhead as the delay approaches 0, and thus
+  // it becomes very likely that our timer loop will fall behind our desired tick rate.
   // we will check that here and tick repeatedly until we catch up
-  if (ticksPerSecond >= 250) {
-    const elapsedMs = Date.now() - startTime
-    const expectedTicks = (elapsedMs / 1000.0) * ticksPerSecond
-    while (numTicks < expectedTicks) {
-      tickInternal()
-    }
+  const elapsedMs = Date.now() - startTime
+  const expectedTicks = (elapsedMs / 1000.0) * ticksPerSecond
+  while (numTicks < expectedTicks) {
+    tickInternal()
   }
 }
 


### PR DESCRIPTION
This PR makes "catching-up" code in tick() unconditional, so that even if we miss a frame, physics keeps ticking along at normal speed.

This is necessary in Firefox, because there Canvas rendering is happening on the CPU. (I am still trying to figure out why that's the case.)

This addresses #547 enough that the game is playable (though very choppy) on high-pixel-density displays.