### PR TITLE
Remove polar coordinates checkbox in level editor

### DIFF
--- a/App/main.js
+++ b/App/main.js
@@ -120,9 +120,9 @@ const ui = {
 
   editorLevelConfigurationButton: $('#editor-level-configuration-button'),
   editorLevelConfigurationDialog: $('#editor-level-configuration-dialog'),
-  editorLevelConfigurationIsPolarCheckbox: $(
-    '#editor-level-configuration-is-polar-checkbox',
-  ),
+  // editorLevelConfigurationIsPolarCheckbox: $(
+  //   '#editor-level-configuration-is-polar-checkbox',
+  // ),
   editorLevelConfigurationBiomeSelect: $(
     '#editor-level-configuration-biome-select',
   ),
@@ -781,10 +781,10 @@ ui.editorLevelConfigurationBiomeSelect.addEventListener('change', () => {
   world.sendEvent('selectBiome', [selectedBiomeKey])
 })
 
-ui.editorLevelConfigurationIsPolarCheckbox.addEventListener('input', () => {
-  const checked = ui.editorLevelConfigurationIsPolarCheckbox.checked
-  world.sendEvent('setPolar', [checked])
-})
+// ui.editorLevelConfigurationIsPolarCheckbox.addEventListener('input', () => {
+//   const checked = ui.editorLevelConfigurationIsPolarCheckbox.checked
+//   world.sendEvent('setPolar', [checked])
+// })
 
 ui.editorLevelConfigurationSledderSelect.addEventListener('input', () => {
   const selectedIndex = ui.editorLevelConfigurationSledderSelect.selectedIndex

--- a/Types/Entities/Level/Editor/LevelEditor.js
+++ b/Types/Entities/Level/Editor/LevelEditor.js
@@ -333,11 +333,11 @@ Share -> open dialog w/ serialized JSON with edit: false, name: "Custom"
     showDialog(ui.editorSharingLinkDialog)
   }
 
-  function setPolar(polar) {
-    graph.polar = polar
-    ui.mathFieldLabel.innerText = `${graph.label}=`
-    self.sendEvent('reset')
-  }
+  // function setPolar(polar) {
+  //   graph.polar = polar
+  //   ui.mathFieldLabel.innerText = `${graph.label}=`
+  //   self.sendEvent('reset')
+  // }
 
   function selectBiome(biomeKey) {
     const biome = BIOMES[biomeKey]
@@ -366,7 +366,7 @@ Share -> open dialog w/ serialized JSON with edit: false, name: "Custom"
     goalDeleted,
     serialize,
 
-    setPolar,
+    // setPolar,
     selectBiome,
     setSledderImage,
 

--- a/index.html
+++ b/index.html
@@ -292,13 +292,13 @@
     <!-- TODO: Make decent -->
     <dialog id="editor-level-configuration-dialog">
       <div class="string">Level Options</div>
-      <div>
+      <!-- <div>
         <label>Polar</label>
         <input
           id="editor-level-configuration-is-polar-checkbox"
           type="checkbox"
         />
-      </div>
+      </div> -->
       <div>
         <label>Biome</label>
         <select id="editor-level-configuration-biome-select">


### PR DESCRIPTION
Removes the polar coordinates checkbox in the level editor as it is not being shipped in 1.0.
The code isn't removed, just commented out for when polar coordinates will be supported.

Fixes #610 