### PR TITLE
Fix editor share dialog style

### DIFF
--- a/App/style.css
+++ b/App/style.css
@@ -392,10 +392,9 @@ input[valid='false'] {
 
 /* TODO: Make copy link dialog for modal look decent */
 
-#share-editor-level-dialog > .hbar {
+#editor-share-dialog > .hbar {
   align-items: center;
   gap: 20px;
-  border: 2px solid #000;
   padding: 0px 10px;
   max-width: 100%;
   margin-top: 10px;

--- a/index.html
+++ b/index.html
@@ -317,10 +317,8 @@
           https://sinerider.com/?auwbdiawdyiubawduybaubydwuhbawdhubawuhbd
         </div> -->
         <input id="puzzle-link" hide="true" />
-        <div>
-          <div class="button" id="editor-copy-puzzle-link">
-            <div class="string">Copy as Puzzle</div>
-          </div>
+        <div class="button" id="editor-copy-puzzle-link">
+          <div class="string">Copy as Puzzle</div>
         </div>
         <div class="button" id="editor-copy-editor-link">
           <div class="string">Copy as Editable</div>


### PR DESCRIPTION
There was an unnecessary `div` surrounding an element in the HTML and a mismatched id in the CSS. Editor share dialog now looks better!