### PR TITLE
Adjust next button text for level editor in accordance with issue #589

### DIFF
--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -610,6 +610,7 @@ function World(spec) {
 
       ui.levelInfoNameStr.innerHTML = levelDatum.name
       ui.levelInfoNickStr.innerHTML = levelDatum.nick
+      ui.nextButtonText.innerHTML = levelDatum.name == "Level Editor" ? "Edit" : "Next"
     }
 
     setNavigating(false)

--- a/Types/Entities/World.js
+++ b/Types/Entities/World.js
@@ -610,7 +610,7 @@ function World(spec) {
 
       ui.levelInfoNameStr.innerHTML = levelDatum.name
       ui.levelInfoNickStr.innerHTML = levelDatum.nick
-      ui.nextButtonText.innerHTML = levelDatum.name == "Level Editor" ? "Edit" : "Next"
+      ui.nextButtonText.innerHTML = levelDatum.name == "Level Editor" ? "Exit" : "Next"
     }
 
     setNavigating(false)


### PR DESCRIPTION
Change the "Next" button text to "Edit" while on the level editor screen.