### PR TITLE
fix(editor): Allow Reverse Paths in Custom Level Editor

### DIFF
--- a/Types/Entities/Goals/PathGoal.js
+++ b/Types/Entities/Goals/PathGoal.js
@@ -215,9 +215,9 @@ function PathGoal(spec) {
     const startY = pathGraph.sample('x', transform.x + pathStart.x)
     const endY = pathGraph.sample('x', transform.x + pathEnd.x)
 
-    bounds.width = pathX
+    bounds.width = Math.abs(pathX)
     bounds.height = height
-    bounds.center = Vector2(pathX / 2 + pathStart.x, verticalCenter)
+    bounds.center = Vector2((pathStart.x + pathEnd.x) / 2, verticalCenter)
 
     leftHandle.transform.position.set(transform.x + pathStart.x, startY)
     rightHandle.transform.position.set(transform.x + pathEnd.x, endY)
@@ -501,15 +501,21 @@ function PathGoal(spec) {
     dragMove(_p)
   }
 
+  const minPathLength = 1
+
   function setStart(newStart) {
-    const newPathStartX = newStart - transform.x
-    setEnds(Math.min(pathEnd.x - 1, newPathStartX), pathEnd.x)
+    const newStartX = newStart - transform.x
+    if (Math.abs(newStartX - pathEnd.x) >= minPathLength) {
+      setEnds(newStartX, pathEnd.x)
+    }
     editor.update(false)
   }
 
   function setEnd(newEnd) {
-    const newPathEndX = newEnd - transform.x
-    setEnds(pathStart.x, Math.max(pathStart.x + 1, newPathEndX))
+    const newEndX = newEnd - transform.x
+    if (Math.abs(newEndX - pathStart.x) >= minPathLength) {
+      setEnds(pathStart.x, newEndX)
+    }
     editor.update(false)
   }
 

--- a/Types/Entities/Level/Editor/LevelEditor.js
+++ b/Types/Entities/Level/Editor/LevelEditor.js
@@ -66,7 +66,7 @@ Share -> open dialog w/ serialized JSON with edit: false, name: "Custom"
         if (g.pathExpression) {
           goalJson.expression = g.pathExpression
           goalJson.expressionLatex = g.pathExpressionLatex
-          goalJson.pathX = g.pathEnd.x
+          goalJson.pathX = g.pathEnd.x - g.pathStart.x
         }
         return goalJson
       }),


### PR DESCRIPTION
## Problem

Path goals in the custom level editor were **restricted to only allow `start point < end point`**. Users couldn't create reverse paths (**`start > end`**) even though official levels support this via negative `pathX` values.

When trying to drag the end point before the start point, it would snap back or fail entirely.

## Root Cause

Three issues prevented reverse paths:

1. **Artificial restrictions**: `setStart()` and `setEnd()` used `Math.min(pathEnd.x - 1, newPathStartX)` and `Math.max(pathStart.x + 1, newPathEndX)` to force start < end
2. **Broken collision detection**: `bounds.width = pathX` breaks hit detection when pathX is negative because `Rect.intersectPoint()` uses `width/2` in comparisons
3. **Wrong serialization**: Saved `pathEnd.x` instead of the actual path length `pathEnd.x - pathStart.x`

## Solution

**PathGoal.js changes:**
- Remove min/max restrictions in `setStart()` and `setEnd()`, keep minimum path length check
- Use `Math.abs(pathX)` for bounds width and correct center calculation

**LevelEditor.js changes:**
- Fix serialization to use `pathEnd.x - pathStart.x`

## Demo

https://github.com/user-attachments/assets/802380e5-0407-402b-877b-5a85b824cfec

@polytroper